### PR TITLE
prevent application payload from being overwritten when adding activities

### DIFF
--- a/app/operations/fdsh/esi/h14/request_esi_determination.rb
+++ b/app/operations/fdsh/esi/h14/request_esi_determination.rb
@@ -33,18 +33,18 @@ module Fdsh
             message: { "#{key}": key == 'request' ? encrypt(value.to_json) : value }
           }
 
-          if key == 'application'
-            application_id = value[:hbx_id]
-            primary_hbx_id = value[:applicants].detect {|applicant| applicant[:is_primary_applicant]}&.dig(:person_hbx_id)
-          end
-
           transaction_hash = {
             correlation_id: activity_hash[:correlation_id],
-            activity: activity_hash,
-            magi_medicaid_application: value.to_json,
-            application_id: application_id,
-            primary_hbx_id: primary_hbx_id
+            activity: activity_hash
           }
+
+          if key == 'application'
+            application_string = value.to_json
+            application_id = value[:hbx_id]
+            primary_hbx_id = value[:applicants].detect {|applicant| applicant[:is_primary_applicant]}&.dig(:person_hbx_id)
+            transaction_hash.merge!(magi_medicaid_application: application_string, application_id: application_id, primary_hbx_id: primary_hbx_id)
+          end
+
           Try do
             Journal::Transactions::AddActivity.new.call(transaction_hash)
           end

--- a/app/operations/fdsh/non_esi/h31/request_non_esi_determination.rb
+++ b/app/operations/fdsh/non_esi/h31/request_non_esi_determination.rb
@@ -33,18 +33,18 @@ module Fdsh
             message: { "#{key}": key == 'request' ? encrypt(value.to_json) : value }
           }
 
-          if key == 'application'
-            application_id = value[:hbx_id]
-            primary_hbx_id = value[:applicants].detect {|applicant| applicant[:is_primary_applicant]}&.dig(:person_hbx_id)
-          end
-
           transaction_hash = {
             correlation_id: activity_hash[:correlation_id],
-            activity: activity_hash,
-            magi_medicaid_application: value.to_json,
-            application_id: application_id,
-            primary_hbx_id: primary_hbx_id
+            activity: activity_hash
           }
+
+          if key == 'application'
+            application_string = value.to_json
+            application_id = value[:hbx_id]
+            primary_hbx_id = value[:applicants].detect {|applicant| applicant[:is_primary_applicant]}&.dig(:person_hbx_id)
+            transaction_hash.merge!(magi_medicaid_application: application_string, application_id: application_id, primary_hbx_id: primary_hbx_id)
+          end
+
           Try do
             Journal::Transactions::AddActivity.new.call(transaction_hash)
           end

--- a/app/operations/journal/transactions/find_or_create.rb
+++ b/app/operations/journal/transactions/find_or_create.rb
@@ -36,8 +36,7 @@ module Journal
       # rubocop:disable Style/MultilineBlockChain
       def find_or_create_transaction(values)
         Try() do
-          ::Transaction.where(correlation_id: values[:correlation_id], magi_medicaid_application: values[:magi_medicaid_application],
-                              application_id: values[:application_id], primary_hbx_id: values[:primary_hbx_id])
+          ::Transaction.where(correlation_id: values[:correlation_id]) # correlation_id is a unique identifier
         end.bind do |result|
           if result.empty?
             Success(::Transaction.new(values))

--- a/spec/operations/fdsh/esi/h14/request_esi_determination_spec.rb
+++ b/spec/operations/fdsh/esi/h14/request_esi_determination_spec.rb
@@ -2,7 +2,11 @@
 
 require 'spec_helper'
 
-RSpec.describe Fdsh::Esi::H14::RequestEsiDetermination do
+RSpec.describe Fdsh::Esi::H14::RequestEsiDetermination, dbclean: :after_each do
+
+  before :all do
+    DatabaseCleaner.clean
+  end
 
   let(:application_params) do
     {

--- a/spec/operations/fdsh/esi/h14/request_esi_determination_spec.rb
+++ b/spec/operations/fdsh/esi/h14/request_esi_determination_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Fdsh::Esi::H14::RequestEsiDetermination, "given valid params" do
+RSpec.describe Fdsh::Esi::H14::RequestEsiDetermination do
 
   let(:application_params) do
     {
@@ -299,11 +299,12 @@ RSpec.describe Fdsh::Esi::H14::RequestEsiDetermination, "given valid params" do
   end
 
   it 'should save the application id on the transaction' do
-    expect(transaction.application_id).not_to eq nil
+    expect(transaction.application_id).to eq application_params[:hbx_id]
   end
 
-  it 'should save the primary hbx id on the transaction field' do
-    expect(transaction.primary_hbx_id).not_to eq nil
+  it 'should save the primary hbx id on the transaction' do
+    primary_applicant = application_params[:applicants].detect {|applicant| applicant[:is_primary_applicant]}
+    expect(transaction.primary_hbx_id).to eq primary_applicant[:person_hbx_id]
   end
 
   it 'should create an application activity on the transaction' do

--- a/spec/operations/fdsh/non_esi/h31/request_non_esi_determination_spec.rb
+++ b/spec/operations/fdsh/non_esi/h31/request_non_esi_determination_spec.rb
@@ -2,7 +2,11 @@
 
 require 'spec_helper'
 
-RSpec.describe Fdsh::NonEsi::H31::RequestNonEsiDetermination do
+RSpec.describe Fdsh::NonEsi::H31::RequestNonEsiDetermination, dbclean: :after_each do
+
+  before :all do
+    DatabaseCleaner.clean
+  end
 
   let(:application_params) do
     {

--- a/spec/operations/fdsh/non_esi/h31/request_non_esi_determination_spec.rb
+++ b/spec/operations/fdsh/non_esi/h31/request_non_esi_determination_spec.rb
@@ -267,6 +267,8 @@ RSpec.describe Fdsh::NonEsi::H31::RequestNonEsiDetermination do
     AcaEntities::MagiMedicaid::Operations::InitializeApplication.new.call(application_params).value!
   end
 
+  let(:transaction) { Transaction.first }
+
   before do
     stub_request(:post, "https://impl.hub.cms.gov/Imp1/VerifyNonEsiMecService")
       .with(
@@ -285,7 +287,36 @@ RSpec.describe Fdsh::NonEsi::H31::RequestNonEsiDetermination do
     described_class.new.call(application, params)
   end
 
-  it "success" do
+  it 'should result in success' do
     expect(subject.success?).to be_truthy
+  end
+
+  it 'should create exactly one new Transaction' do
+    expect(Transaction.count).to eq 1
+  end
+
+  it 'should save the application on the transaction' do
+    expect(transaction.magi_medicaid_application).to eq JSON.generate(application.to_h)
+  end
+
+  it 'should save the application id on the transaction' do
+    expect(transaction.application_id).to eq application_params[:hbx_id]
+  end
+
+  it 'should save the primary hbx id on the transaction' do
+    primary_applicant = application_params[:applicants].detect {|applicant| applicant[:is_primary_applicant]}
+    expect(transaction.primary_hbx_id).to eq primary_applicant[:person_hbx_id]
+  end
+
+  it 'should create an application activity on the transaction' do
+    application_activity = transaction.activities.select {|activity| activity.message.keys[0] == 'application' }
+    expect(application_activity.count).to eq 1
+    expect(application_activity.present?).to be_truthy
+  end
+
+  it 'should create a request activity on the transaction' do
+    request_activity = transaction.activities.select {|activity| activity.message.keys[0] == 'request' }
+    expect(request_activity.count).to eq 1
+    expect(request_activity.present?).to be_truthy
   end
 end

--- a/spec/operations/journal/transactions/find_or_create_spec.rb
+++ b/spec/operations/journal/transactions/find_or_create_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Journal::Transactions::FindOrCreate do
   let(:request_event_attributes) { RequestEventAttributes }
 
   context 'Operation is called without params' do
-    let(:errors) { {:correlation_id=>["is missing", "must be a string"]} }
+    let(:errors) { { :correlation_id => ["is missing", "must be a string"] } }
     it 'should fail validation' do
       expect(described_class.new.call({}).success?).to be_falsey
       expect(described_class.new.call({}).failure.errors.to_h).to eq errors
@@ -20,12 +20,12 @@ RSpec.describe Journal::Transactions::FindOrCreate do
   context 'Operation is called using a :correlation_id with no matching database record' do
     let(:correlation_id) { 'brand_new_id' }
     let(:result) { described_class.new.call(correlation_id: correlation_id) }
-    
+
     before do
-        expect(Transaction.count).to eq 0        
+      expect(Transaction.count).to eq 0
     end
-   
-    it 'should create a new Transaction record' do      
+
+    it 'should create a new Transaction record' do
       expect(result.success?).to eq true
       expect(Transaction.first.correlation_id).to eq 'brand_new_id'
     end

--- a/spec/operations/journal/transactions/find_or_create_spec.rb
+++ b/spec/operations/journal/transactions/find_or_create_spec.rb
@@ -4,6 +4,11 @@ require 'rails_helper'
 require_relative '../shared_setup'
 
 RSpec.describe Journal::Transactions::FindOrCreate do
+
+  before :all do
+    DatabaseCleaner.clean
+  end
+
   let(:request_command) { 'request_fdsh_ifsv_determination' }
   let(:request_event_key) { 'VLPService' }
   let(:correlation_id) { '120012300' }

--- a/spec/operations/journal/transactions/find_or_create_spec.rb
+++ b/spec/operations/journal/transactions/find_or_create_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../shared_setup'
+
+RSpec.describe Journal::Transactions::FindOrCreate do
+  let(:request_command) { 'request_fdsh_ifsv_determination' }
+  let(:request_event_key) { 'VLPService' }
+  let(:correlation_id) { '120012300' }
+  let(:request_event_attributes) { RequestEventAttributes }
+
+  context 'Operation is called without params' do
+    let(:errors) { {:correlation_id=>["is missing", "must be a string"]} }
+    it 'should fail validation' do
+      expect(described_class.new.call({}).success?).to be_falsey
+      expect(described_class.new.call({}).failure.errors.to_h).to eq errors
+    end
+  end
+
+  context 'Operation is called using a :correlation_id with no matching database record' do
+    let(:correlation_id) { 'brand_new_id' }
+    let(:result) { described_class.new.call(correlation_id: correlation_id) }
+    
+    before do
+        expect(Transaction.count).to eq 0        
+    end
+   
+    it 'should create a new Transaction record' do      
+      expect(result.success?).to eq true
+      expect(Transaction.first.correlation_id).to eq 'brand_new_id'
+    end
+  end
+
+  context 'An activitiy record is added to the database' do
+    let(:request_event) do
+      {
+        headers: {
+          correlation_id: correlation_id
+        },
+        attributes: request_event_attributes
+      }
+    end
+
+    let(:request_activity) do
+      {
+        event_key: request_event_key,
+        command: request_command,
+        correlation_id: request_event[:headers][:correlation_id],
+        message: request_event_attributes.merge(request_id: correlation_id)
+      }
+    end
+
+    it 'should find and return a Transaction hash for the supplied :correlation_id' do
+      transaction =
+        Journal::Transactions::AddActivity.new.call(
+          correlation_id: correlation_id,
+          activity: request_activity
+        )
+
+      result =
+        described_class.new.call(
+          correlation_id: transaction.value![:correlation_id]
+        )
+      expect(::Transaction.count).to be > 0
+      expect(result.success?).to be_truthy
+      expect(result.value!.to_h[:correlation_id]).to eq correlation_id
+    end
+  end
+end


### PR DESCRIPTION
https://redmine.dchbx.org/issues/98416

Save application payload, application id and primary hbx id  to transaction model in ESI and non-ESI determination requests only where appropriate.  Prevent overwriting of application payload on subsequent create/update actions. 

