### PR TITLE
log ids of transactions missing historical data in activity row script

### DIFF
--- a/lib/tasks/populate_activity_row.rake
+++ b/lib/tasks/populate_activity_row.rake
@@ -11,7 +11,7 @@ namespace :update do
     count = 0
     Transaction.no_timeout.each do |t|
       t.activities.no_timeout.each do |a|
-        row = {
+        row_params = {
           transaction_id: t._id,
           application_id: t.application_id,
           primary_hbx_id: t.primary_hbx_id,
@@ -21,9 +21,25 @@ namespace :update do
           status: a.status,
           message: a.message
         }
-        ::ActivityRow.create(row)
-        count += 1
-        puts "Activity_row created for activity: #{a.correlation_id.strip} on transaction: #{t._id}"
+        next if ActivityRow.where(row_params).first
+
+        activity_row = ::ActivityRow.new do |ar|
+          ar.transaction_id = t._id
+          ar.application_id = t.application_id
+          ar.primary_hbx_id = t.primary_hbx_id
+          ar.fpl_year = t.fpl_year
+          ar.correlation_id = a.correlation_id
+          ar.activity_name = a.event_key_label
+          ar.status = a.status
+          ar.message = a.message
+        end
+        result = activity_row.save
+        if result
+          count += 1
+          puts "Activity_row created for activity: #{a.correlation_id.strip} on transaction: #{t._id}"
+        else
+          puts "Activity_row FAILED to create for activity: #{a.correlation_id.strip} on transaction: #{t._id}"
+        end
       end
     end
     end_time = Process.clock_gettime(Process::CLOCK_REALTIME)

--- a/lib/tasks/populate_missing_activity_row_fields.rake
+++ b/lib/tasks/populate_missing_activity_row_fields.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Report: Rake task to Populate activity_row collection with historical data
-# format: RAILS_ENV=production bundle exec rake update:populate_activity_row
+# format: bundle exec rake update:populate_missing_activity_row_fields
 
 namespace :update do
   desc "Populate activity row collection with missing data that was calculated in view"
@@ -18,9 +18,17 @@ namespace :update do
       params = {}
       params[:application_id] = app if row.application_id.blank? && app.present?
       params[:primary_hbx_id] = hbx if row.primary_hbx_id.blank? && hbx.present?
-      row.update(params) if params.present?
-      count += 1
-      puts "ActivityRow #{row.correlation_id.strip} updated with #{params}"
+      if params.present?
+        result = row.update(params)
+        if result
+          count += 1
+          puts "ActivityRow #{row.correlation_id.strip} updated with #{params}"
+        else
+          puts "ActivityRow #{row.correlation_id.strip} FAILED to update with #{params}"
+        end
+      else
+        puts "Application ID and primary HBX ID NOT FOUND for correlation_id #{t.correlation_id.strip}"
+      end
     end
 
     end_time = Process.clock_gettime(Process::CLOCK_REALTIME)


### PR DESCRIPTION
[IVL-183234350](https://www.pivotaltracker.com/n/projects/2481183/stories/183234350)

populate_activity_row.rake:
- log failures to create record
- check for existence of activity row before creating new one

populate_missing_activity_row_fields.rake:
- log failures to update record
- log correlation_id for transactions where application_id and primary_hbx_id is not found in historical data
