### PR TITLE
refactor untransmitted transactions migration to always pull the latest 2022 original transmission

### DIFF
--- a/app/models/transmittable/transmission.rb
+++ b/app/models/transmittable/transmission.rb
@@ -62,6 +62,7 @@ module Transmittable
     field :ended_at, type: DateTime
 
     # Indexes
+    index({ created_at: 1 })
     index({ status: 1 })
 
     # Scopes

--- a/app/operations/fdsh/h41/transmissions/find.rb
+++ b/app/operations/fdsh/h41/transmissions/find.rb
@@ -39,20 +39,22 @@ module Fdsh
         end
 
         def find_open_transmission(values)
-          case values[:transmission_type]
-          when :corrected
-            ::H41::Transmissions::Outbound::CorrectedTransmission.where(
-              status: values[:status]
-            ).by_year(values[:reporting_year]).first
-          when :original
-            ::H41::Transmissions::Outbound::OriginalTransmission.where(
-              status: values[:status]
-            ).by_year(values[:reporting_year]).first
-          else
-            ::H41::Transmissions::Outbound::VoidTransmission.where(
-              status: values[:status]
-            ).by_year(values[:reporting_year]).first
-          end
+          open_tranmssions = case values[:transmission_type]
+                             when :corrected
+                               ::H41::Transmissions::Outbound::CorrectedTransmission.where(
+                                 status: values[:status]
+                               ).by_year(values[:reporting_year]).order(:created_at.asc)
+                             when :original
+                               ::H41::Transmissions::Outbound::OriginalTransmission.where(
+                                 status: values[:status]
+                               ).by_year(values[:reporting_year]).order(:created_at.asc)
+                             else
+                               ::H41::Transmissions::Outbound::VoidTransmission.where(
+                                 status: values[:status]
+                               ).by_year(values[:reporting_year]).order(:created_at.asc)
+                             end
+
+          values[:latest] ? open_tranmssions.last : open_tranmssions.first
         end
 
         def validate(params)

--- a/script/handle_untransmitted_transactions.rb
+++ b/script/handle_untransmitted_transactions.rb
@@ -4,9 +4,11 @@
 # Updates untransmitted transactions of transmitted transmission status: :superseded, transmit_action: :no_transmit
 # bundle exec rails runner script/handle_untransmitted_transactions.rb
 
+# Finds the latest 2022 Original Transmission of given 'status' if there are more than 1 in the same status for the same year
 def find_h41_transmission(status)
   ::Fdsh::H41::Transmissions::Find.new.call(
     {
+      latest: true,
       reporting_year: 2022,
       status: status,
       transmission_type: :original

--- a/spec/operations/fdsh/h41/transmissions/find_spec.rb
+++ b/spec/operations/fdsh/h41/transmissions/find_spec.rb
@@ -35,6 +35,34 @@ RSpec.describe Fdsh::H41::Transmissions::Find do
         end
       end
 
+      context 'with more than 1 original open H41 transmission' do
+        let(:status) { :open }
+        let(:transmission_type) { :original }
+        let!(:h41_original_transmission1) { FactoryBot.create(:h41_original_transmission) }
+        let!(:h41_original_transmission2) { FactoryBot.create(:h41_original_transmission) }
+
+        context 'with argument :latest set to true' do
+          let(:input_params) do
+            {
+              latest: true,
+              reporting_year: Date.today.year,
+              status: status,
+              transmission_type: transmission_type
+            }
+          end
+
+          it 'returns the latest existing open H41 transmission' do
+            expect(subject.success).to eq(h41_original_transmission2)
+          end
+        end
+
+        context 'without argument :latest' do
+          it 'returns the first existing open H41 transmission' do
+            expect(subject.success).to eq(h41_original_transmission1)
+          end
+        end
+      end
+
       context 'with an corrected open H41 transmission' do
         let(:status) { :open }
         let(:transmission_type) { :corrected }


### PR DESCRIPTION
Refactor Untransmitted Transactions Migration to pull the latest(by created_at) 2022 original transmission of the given status.