### PR TITLE
update header key for esi mec

### DIFF
--- a/app/event_source/subscribers/fdsh/determination_requests/esi_mec_eligibility_determination_subscriber.rb
+++ b/app/event_source/subscribers/fdsh/determination_requests/esi_mec_eligibility_determination_subscriber.rb
@@ -14,7 +14,7 @@ module Subscribers
           # Sequence of steps that are executed as single operation
           correlation_id = properties.correlation_id
           event_key = "determine_esi_mec_eligibility"
-          esi_payload_format = properties[:headers]['esi_payload_format']
+          esi_payload_format = properties[:headers]['esi_mec_payload_format']
           determination_result = if esi_payload_format == 'json'
                                    ::Fdsh::Esi::Rj14::HandleJsonEligibilityDeterminationRequest.new.call({
                                                                                                            payload: payload,

--- a/app/event_source/subscribers/fdsh/determination_requests/evidences_mec_eligibility_determination_subscriber.rb
+++ b/app/event_source/subscribers/fdsh/determination_requests/evidences_mec_eligibility_determination_subscriber.rb
@@ -13,7 +13,7 @@ module Subscribers
         subscribe(:on_esi_determination_requested) do |delivery_info, properties, payload|
           # Sequence of steps that are executed as single operation
           correlation_id = properties.correlation_id
-          esi_payload_format = properties[:headers]['esi_payload_format']
+          esi_payload_format = properties[:headers]['esi_mec_payload_format']
           esi_result = if esi_payload_format == 'json'
                          ::Fdsh::Esi::Rj14::HandleJsonEligibilityDeterminationRequest.new.call({
                                                                                                  payload: payload,

--- a/app/event_source/subscribers/fdsh/determination_requests/mec_eligibility_determination_subscriber.rb
+++ b/app/event_source/subscribers/fdsh/determination_requests/mec_eligibility_determination_subscriber.rb
@@ -13,7 +13,7 @@ module Subscribers
         subscribe(:on_magi_medicaid_application_determined) do |delivery_info, properties, payload|
           # Sequence of steps that are executed as single operation
           correlation_id = properties.correlation_id
-          esi_payload_format = properties[:headers]['esi_payload_format']
+          esi_payload_format = properties[:headers]['esi_mec_payload_format']
           esi_result = if esi_payload_format == 'json'
                          ::Fdsh::Esi::Rj14::HandleJsonEligibilityDeterminationRequest.new.call({
                                                                                                  payload: payload,


### PR DESCRIPTION
there was a mismatch between fdsh_gateway and enroll as to what the key for the esi json payload type was. this switched the fdsh key to match enrolls