### PR TITLE
change means of accessing payload_type header

### DIFF
--- a/app/event_source/subscribers/fdsh/verification_requests/vlp_verification_requested_subscriber.rb
+++ b/app/event_source/subscribers/fdsh/verification_requests/vlp_verification_requested_subscriber.rb
@@ -13,7 +13,7 @@ module Subscribers
           # Sequence of steps that are executed as single operation
           # puts "triggered --> on_primary_request block -- #{delivery_info} --  #{metadata} -- #{payload}"
           correlation_id = properties.correlation_id
-          payload_type = properties.payload_type
+          payload_type = properties[:headers]["payload_type"]
 
           verification_result = if payload_type == "rest_xml"
                                   Fdsh::Vlp::Rx142::InitialVerification::HandleInitialVerificationRequest.new.call({ payload: payload,


### PR DESCRIPTION
Ticket [#186771013](https://www.pivotaltracker.com/story/show/186771013)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the method of accessing `payload_type` for improved event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->