### PR TITLE
remove sign up option from devise config and app layout

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User
   include Mongoid::Document
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable,
          :recoverable, :rememberable, :validatable
 
   ## Database authenticatable

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,6 @@
                   <li class='nav-item'><%= link_to 'Sign out', destroy_user_session_path, :method=>'delete', class: 'nav-link' %></li>
                 <% else %>
                   <li class='nav-item'><%= link_to 'Sign in', new_user_session_path, class: 'nav-link' %></li>
-                  <li class='nav-item'><%= link_to 'Sign up', new_user_registration_path, class: 'nav-link' %></li>
                 <% end %>
               </ul>
             </div>


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/2640057/stories/186905706

Removes Devise registerable configuration, such that:
1. User will not be able to see the "Sign Up" hyper link on the FDSH home page. 
1. User will not be able to see the "Sign Up" hyper link on the FDSH settings drop down. 
1. User will not be able to navigate to the "Sign Up" URL ending in "users/sign_up"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined user authentication by removing self-registration capabilities.

- **Style**
	- Updated the navigation layout by removing the "Sign up" link for unauthenticated users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->