### PR TITLE
create matching jobs and return failures to EA

### DIFF
--- a/app/operations/fdsh/jobs/create_job.rb
+++ b/app/operations/fdsh/jobs/create_job.rb
@@ -26,7 +26,7 @@ module Fdsh
 
       def create_job_hash(values)
         Success({
-                  job_id: generate_job_id(values[:key]),
+                  job_id: generate_job_id(values[:key], values[:job_id]),
                   saga_id: values[:saga_id],
                   key: values[:key],
                   title: values[:title],
@@ -49,7 +49,8 @@ module Fdsh
         validation_result.success? ? Success(validation_result.value!) : Failure("Unable to create job due to invalid params")
       end
 
-      def generate_job_id(key)
+      def generate_job_id(key, job_id)
+        return job_id if job_id
         "#{key}_#{Time.now.to_i}"
       end
 

--- a/app/operations/fdsh/jobs/find_or_create_job.rb
+++ b/app/operations/fdsh/jobs/find_or_create_job.rb
@@ -27,7 +27,7 @@ module Fdsh
         if values[:job_id]
           job = Transmittable::Job.where(job_id: values[:job_id]).last
 
-          job ? Success(job) : Failure("No job exists with the given job_id")
+          job ? Success(job) : create_job(values)
 
         elsif values[:message_id]
           job = Transmittable::Job.where(message_id: values[:message_id]).last

--- a/app/operations/fdsh/ssa/h3/handle_json_ssa_verification_request.rb
+++ b/app/operations/fdsh/ssa/h3/handle_json_ssa_verification_request.rb
@@ -39,7 +39,8 @@ module Fdsh
                                                                             payload: params[:payload],
                                                                             correlation_id: params[:correlation_id],
                                                                             started_at: DateTime.now,
-                                                                            publish_on: DateTime.now })
+                                                                            publish_on: DateTime.now,
+                                                                            job_id: params[:job_id] })
 
           result.success? ? Success(result.value!) : result
         end
@@ -173,7 +174,8 @@ module Fdsh
         def build_event(correlation_id, response)
           payload = response.to_h
 
-          event('events.fdsh.ssa_verification_complete', attributes: payload, headers: { correlation_id: correlation_id })
+          event('events.fdsh.ssa_verification_complete', attributes: payload,
+                                                         headers: { correlation_id: correlation_id, job_id: @job.job_id, status: "success" })
         end
 
         def publish(event)

--- a/spec/operations/fdsh/jobs/find_or_create_job_spec.rb
+++ b/spec/operations/fdsh/jobs/find_or_create_job_spec.rb
@@ -70,9 +70,10 @@ RSpec.describe Fdsh::Jobs::FindOrCreateJob, dbclean: :after_each do
       expect(result.value!).to eq job
     end
 
-    it 'should return failure when sending invalid job_id' do
+    it 'should return create a job with given job_id' do
       result = subject.call(required_params.merge(job_id: "random"))
-      expect(result.failure).to eq "No job exists with the given job_id"
+      expect(result.value!.class).to eq Transmittable::Job
+      expect(result.value!.job_id).to eq "random"
     end
 
     it 'should return the existing job when message_id is provided' do

--- a/spec/operations/fdsh/ssa/h3/handle_json_ssa_verification_request_spec.rb
+++ b/spec/operations/fdsh/ssa/h3/handle_json_ssa_verification_request_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Fdsh::Ssa::H3::HandleJsonSsaVerificationRequest, dbclean: :after_
   let(:mock_transmittable_payload_response) { Dry::Monads::Result::Success.call(transmittable_hash) }
   let(:mock_jwt_request) { instance_double(Jwt::GetJwt) }
   let(:mock_jwt_response) { Dry::Monads::Result::Success.call("3487583567384567384568") }
-  let(:mock_ssa_request_verification) { instance_double(::Fdsh::Ssa::H3::RequestJsonSsaVerification) }
+  let(:mock_ssa_request_verification) { instance_double(Fdsh::Ssa::H3::RequestJsonSsaVerification) }
   let(:mock_ssa_response) { Dry::Monads::Result::Success.call(Faraday::Response.new(status: 200, response_body: mock_ssa_response_body.to_json)) }
   let!(:mock_ssa_response_body) do
     { "ssaCompositeResponse" =>
@@ -35,7 +35,8 @@ RSpec.describe Fdsh::Ssa::H3::HandleJsonSsaVerificationRequest, dbclean: :after_
                                                                        payload: payload,
                                                                        correlation_id: correlation_id,
                                                                        started_at: DateTime.now,
-                                                                       publish_on: DateTime.now
+                                                                       publish_on: DateTime.now,
+                                                                       job_id: nil
                                                                      }).and_return(mock_transmittable_payload_response)
     allow(Jwt::GetJwt).to receive(:new).and_return(mock_jwt_request)
     allow(mock_jwt_request).to receive(:call).with({}).and_return(mock_jwt_response)


### PR DESCRIPTION
Reference ticket - [186938487](https://www.pivotaltracker.com/story/show/186938487)
Creates job with given job_id
Returns failures to EA in case of failure for SSA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced job handling by incorporating a unique identifier (`job_id`) for better tracking and management of verification requests.
- **Bug Fixes**
	- Improved the reliability of job creation and verification request processes by ensuring jobs are correctly created or found, enhancing error handling and failure response mechanisms.
- **Refactor**
	- Streamlined verification request handling by including `job_id` in key operations, improving the system's efficiency and traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->