### PR TITLE
add devise registerable and update sign out

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,7 +38,7 @@ class User
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable,
          :recoverable, :rememberable, :validatable,
-         :trackable, :session_limitable, :expirable
+         :trackable, :session_limitable, :expirable, :registerable
 
   ## Database authenticatable
   field :email,              type: String, default: ""

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -36,8 +36,4 @@
   </div>
 <% end %>
 
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
 <%= link_to "Back", :back %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -2,10 +2,6 @@
   <%= link_to "Log in", new_session_path(resource_name) %><br />
 <% end %>
 
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
-<% end %>
-
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
   <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,8 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    
   </head>
 
   <body>
@@ -24,7 +26,7 @@
               <ul>
                 <% if user_signed_in? %>
                   <li class='nav-item'><%= link_to 'Edit account', edit_user_registration_path, class: 'nav-link' %></li>
-                  <li class='nav-item'><%= link_to 'Sign out', destroy_user_session_path, :method=>'delete', class: 'nav-link' %></li>
+                  <li class='nav-item'><%= link_to 'Sign out', destroy_user_session_path, method: :delete, class: 'nav-link' %></li>
                 <% else %>
                   <li class='nav-item'><%= link_to 'Sign in', new_user_session_path, class: 'nav-link' %></li>
                 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
               <ul>
                 <% if user_signed_in? %>
                   <li class='nav-item'><%= link_to 'Edit account', edit_user_registration_path, class: 'nav-link' %></li>
-                  <li class='nav-item'><%= link_to 'Sign out', destroy_user_session_path, :method => 'delete', class: 'nav-link' %></li>
+                  <li class='nav-item'><%= link_to 'Sign out', destroy_user_session_path, :method=> 'delete', class: 'nav-link' %></li>
                 <% else %>
                   <li class='nav-item'><%= link_to 'Sign in', new_user_session_path, class: 'nav-link' %></li>
                 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
               <ul>
                 <% if user_signed_in? %>
                   <li class='nav-item'><%= link_to 'Edit account', edit_user_registration_path, class: 'nav-link' %></li>
-                  <li class='nav-item'><%= link_to 'Sign out', destroy_user_session_path, method: :delete, class: 'nav-link' %></li>
+                  <li class='nav-item'><%= link_to 'Sign out', destroy_user_session_path, :method => 'delete', class: 'nav-link' %></li>
                 <% else %>
                   <li class='nav-item'><%= link_to 'Sign in', new_user_session_path, class: 'nav-link' %></li>
                 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
               <ul>
                 <% if user_signed_in? %>
                   <li class='nav-item'><%= link_to 'Edit account', edit_user_registration_path, class: 'nav-link' %></li>
-                  <li class='nav-item'><%= link_to 'Sign out', destroy_user_session_path, :method=> 'delete', class: 'nav-link' %></li>
+                  <li class='nav-item'><%= link_to 'Sign out', destroy_user_session_path, :method=>'delete', class: 'nav-link' %></li>
                 <% else %>
                   <li class='nav-item'><%= link_to 'Sign in', new_user_session_path, class: 'nav-link' %></li>
                 <% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -267,7 +267,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :delete
+  config.sign_out_via = :get
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -267,7 +267,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :get
+  config.sign_out_via = :delete
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,15 @@
 
 Rails.application.routes.draw do
 
-  devise_for :users
+  devise_for :users, :skip => [:registrations] 
+    as :user do
+    get 'users/edit' => 'devise/registrations#edit', :as => 'edit_user_registration'
+    put 'users' => 'devise/registrations#update', :as => 'user_registration'
+    end
+
+  devise_scope :user do
+    get '/users/sign_out' => 'devise/sessions#destroy'
+  end  
 
   root 'activity_row#index'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,13 +2,10 @@
 
 Rails.application.routes.draw do
 
-  devise_for :users, :skip => [:registrations]
-  as :user do
-    get 'users/edit' => 'devise/registrations#edit', :as => 'edit_user_registration'
-    put 'users' => 'devise/registrations#update', :as => 'user_registration'
-  end
-
+  devise_for :users, skip: [:registrations]
   devise_scope :user do
+    get 'users/edit' => 'devise/registrations#edit', as: 'edit_user_registration'
+    put 'users' => 'devise/registrations#update', as: 'user_registration'
     get '/users/sign_out' => 'devise/sessions#destroy'
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,15 +2,15 @@
 
 Rails.application.routes.draw do
 
-  devise_for :users, :skip => [:registrations] 
-    as :user do
+  devise_for :users, :skip => [:registrations]
+  as :user do
     get 'users/edit' => 'devise/registrations#edit', :as => 'edit_user_registration'
     put 'users' => 'devise/registrations#update', :as => 'user_registration'
-    end
+  end
 
   devise_scope :user do
     get '/users/sign_out' => 'devise/sessions#destroy'
-  end  
+  end
 
   root 'activity_row#index'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,6 @@ Rails.application.routes.draw do
   devise_scope :user do
     get 'users/edit' => 'devise/registrations#edit', as: 'edit_user_registration'
     put 'users' => 'devise/registrations#update', as: 'user_registration'
-    get '/users/sign_out' => 'devise/sessions#destroy'
   end
 
   root 'activity_row#index'


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/2640060/stories/186972351

As part of the implementation of [ME-186972351](https://www.pivotaltracker.com/n/projects/2640060/stories/186972351) we added the gem devise-security which upgraded Devise. We have to tweak Devise a bit to properly configure registerable and allow users to sign out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved user registration process by adding the `:registerable` option.
	- Enhanced user experience by changing sign-out method to be more user-friendly.
- **Refactor**
	- Customized Devise routes for better user management.
	- Simplified registration form by removing account cancellation option.
	- Updated shared links to hide "Sign up" link on registrations page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->