### PR TITLE
do not generate h41 if there are no pending transactions

### DIFF
--- a/app/operations/fdsh/h41/transmissions/publish.rb
+++ b/app/operations/fdsh/h41/transmissions/publish.rb
@@ -117,9 +117,16 @@ module Fdsh
         end
 
         def publish_h41_transmisson(transmission, values)
+          pending_transactions = transmission.transactions.transmit_pending
+          if pending_transactions.blank?
+            return Success(
+              "No pending transactions for : #{values[:report_type]}"
+            )
+          end
+
           if values[:report_type] == :original
             new_batch_reference = construct_new_batch_reference(:original, 0)
-            create_transmission_with(transmission.transactions.transmit_pending, values, new_batch_reference)
+            create_transmission_with(pending_transactions, values, new_batch_reference)
           else
             find_transactions_by_original_batch(transmission, values).each_with_index do |(batch_reference, transactions), index|
               new_batch_reference = construct_new_batch_reference(values[:report_type], index)

--- a/spec/operations/fdsh/h41/transmissions/publish_spec.rb
+++ b/spec/operations/fdsh/h41/transmissions/publish_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Fdsh::H41::Transmissions::Publish do
   context "no pending transactions for transmission" do
     let!(:insurance_polices) do
       create_list(:h41_insurance_policy, 20, :with_aptc_csr_tax_households, transaction_xml: transaction_xml,
-                  transmission: open_transmission)
+                                                                            transmission: open_transmission)
     end
 
     let(:outbound_folder) do

--- a/spec/operations/fdsh/h41/transmissions/publish_spec.rb
+++ b/spec/operations/fdsh/h41/transmissions/publish_spec.rb
@@ -56,6 +56,41 @@ RSpec.describe Fdsh::H41::Transmissions::Publish do
     end
   end
 
+  context "no pending transactions for transmission" do
+    let!(:insurance_polices) do
+      create_list(:h41_insurance_policy, 20, :with_aptc_csr_tax_households, transaction_xml: transaction_xml,
+                  transmission: open_transmission)
+    end
+
+    let(:outbound_folder) do
+      Rails.root.join("h41_transmissions").to_s
+    end
+
+    let(:input_params) do
+      {
+        reporting_year: Date.today.year,
+        report_kind: :h41,
+        report_type: :original
+      }
+    end
+
+    let!(:open_transmission) { FactoryBot.create(:h41_original_transmission) }
+    let(:transaction_xml) do
+      File.read(Rails.root.join("spec/test_payloads/h41/original.xml").to_s)
+    end
+
+    it 'should leave transmission in processing state' do
+      open_transmission.transactions.update_all(status: :blocked, transmit_action: :no_transmit)
+      @result = subject.call(input_params)
+      open_transmission.reload
+      expect(open_transmission.status).to eq :processing
+    end
+
+    it 'should not create h41_transmissons directory' do
+      expect(Dir.exist?(Rails.root.join("h41_transmissions").to_s)).to be_falsey
+    end
+  end
+
   describe '.publish' do
     let!(:insurance_polices) do
       create_list(:h41_insurance_policy, 20, :with_aptc_csr_tax_households, transaction_xml: transaction_xml,


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186985085

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved efficiency by adding a check for pending transactions before processing.
- **Tests**
	- Ensured reliability with new tests for scenarios without pending transactions.
- **Refactor**
	- Enhanced code clarity by updating method logic to use `pending_transactions` for creating new transmissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->